### PR TITLE
LZ-SA-estimated-next-purchase

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -3,6 +3,8 @@ import { useHistory } from 'react-router-dom';
 import { FirestoreCollection, withFirestore } from 'react-firestore';
 import Item from './Item';
 import '../styles/List.css';
+import calculateEstimate from '../lib/estimates'
+import secondsToDays from '../lib/secondsToDays'
 
 const List = ({ firestore }) => {
   const token = localStorage.getItem('userToken');
@@ -15,6 +17,9 @@ const List = ({ firestore }) => {
   };
 
   const handleChange = (e, item) => {
+    const daysInterval = secondsToDays((Date.now()/1000) - item.lastPurchasedDate['seconds'])
+    const estimate = calculateEstimate(item.nextPurchase, daysInterval, item.numberOfPurchases)
+
     const purchased = item.numberOfPurchases;
     // TODO: Need some error handling here
     if (e.target.checked) {
@@ -24,6 +29,7 @@ const List = ({ firestore }) => {
         .update({
           numberOfPurchases: purchased + 1,
           lastPurchasedDate: new Date(),
+          nextPurchase: estimate
         });
     }
   };

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -3,8 +3,8 @@ import { useHistory } from 'react-router-dom';
 import { FirestoreCollection, withFirestore } from 'react-firestore';
 import Item from './Item';
 import '../styles/List.css';
-import calculateEstimate from '../lib/estimates'
-import secondsToDays from '../lib/secondsToDays'
+import calculateEstimate from '../lib/estimates';
+import secondsToDays from '../lib/secondsToDays';
 
 const List = ({ firestore }) => {
   const token = localStorage.getItem('userToken');
@@ -17,11 +17,18 @@ const List = ({ firestore }) => {
   };
 
   const handleChange = (e, item) => {
-    const daysInterval = secondsToDays((Date.now()/1000) - item.lastPurchasedDate['seconds'])
-    const estimate = calculateEstimate(item.nextPurchase, daysInterval, item.numberOfPurchases)
+    const daysInterval = secondsToDays(
+      Date.now() / 1000 - item.lastPurchasedDate['seconds'],
+    );
+    const weightedNextPurchaseEstimate = calculateEstimate(
+      item.nextPurchase,
+      daysInterval,
+      item.numberOfPurchases,
+    );
 
     const purchased = item.numberOfPurchases;
-    // TODO: Need some error handling here
+    // TODO: Need some error handling here to prevent user from unchecking and rechecking the box within 24
+    // hours of last checked date
     if (e.target.checked) {
       firestore
         .collection('shoppingList')
@@ -29,7 +36,7 @@ const List = ({ firestore }) => {
         .update({
           numberOfPurchases: purchased + 1,
           lastPurchasedDate: new Date(),
-          nextPurchase: estimate
+          nextPurchase: weightedNextPurchaseEstimate,
         });
     }
   };

--- a/src/lib/secondsToDays.js
+++ b/src/lib/secondsToDays.js
@@ -1,0 +1,6 @@
+const secondsToDays = (seconds)  => {
+  const days = Math.floor(Number(seconds) / (3600*24));
+  return days
+}
+
+export default secondsToDays


### PR DESCRIPTION
## Description

- In List.js, we calculated the time interval between the item's purchased date (current date) and the `lastPurchaseDate`, and converted that to days. Then, we use the `calculateEstimate` function to recalculate a nextPurchase interval for that item based on a weighted average using the prior nextPurchase interval, actual interval, and number of purchases. When the item is checked (bought), the estimated days interval is used to update the item's `nextPurchase` in firebase. 
- We created a helper function to convert seconds to days in `lib` folder.

## Related Issue

Closes #10 

## Acceptance Criteria

- When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :sparkles: New feature     |

## Updates

No UI changes.

## Testing Steps / QA Criteria

1. In the web app, clear out any existing userToken in local storage. Then join an existing list using the token `walton twill litton`
2. In firebase console, filter the shoppingList using condition token == "walton twill litton" to see the items.
3. In firebase console, update the `lastPurchasedDate` of one of the items for that list to be at least 1 day prior to the current date.
4. In the web app, check that item as bought. 
5. Verify that the next purchase date of that item is updated to a newly calculated value.
