### PR TITLE
LZ-LB-item-details

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,9 +1,19 @@
 import React, { useState, useEffect } from 'react';
+import Modal from './Modal.js';
 import '../styles/Item.css';
+import dayjs from 'dayjs';
 
-const Item = ({ item, handleChange, deleteItem }) => {
+const Item = ({
+  item,
+  handleChange,
+  deleteItem,
+  showModal,
+  setModalDisplay,
+}) => {
   const [checked, setChecked] = useState(false);
   const className = checked ? 'completed' : '';
+  const today = dayjs().format('d');
+  const estimatedNextPurchaseDate = +today + item.nextPurchase;
 
   useEffect(() => {
     const checkDate = () => {
@@ -25,21 +35,37 @@ const Item = ({ item, handleChange, deleteItem }) => {
   }, [item]);
 
   return (
-    <li className="list-item">
-      <input
-        className="checkbox"
-        type="checkbox"
-        checked={checked}
-        onChange={e => handleChange(e, item)}
-        id={item.id}
-      />
-      <label htmlFor={item.id} className={className}>
-        {item.name} - next purchase in {item.nextPurchase} days
-      </label>
-      <button className="delete" onClick={() => deleteItem(item.id)}>
-        Delete
-      </button>
-    </li>
+    <>
+      <li className="list-item">
+        <label htmlFor={item.id} onClick={() => console.log('here')}>
+          <input
+            className="checkbox"
+            type="checkbox"
+            checked={checked}
+            onChange={e => handleChange(e, item)}
+            id={item.id}
+          />
+        </label>
+
+        <span className={className} onClick={() => setModalDisplay(true)}>
+          {item.name} - next purchase in {item.nextPurchase} days
+        </span>
+
+        <button className="delete" onClick={() => deleteItem(item.id)}>
+          Delete
+        </button>
+      </li>
+      {showModal && (
+        <Modal setDisplay={setModalDisplay}>
+          <h1>{item.name}</h1>
+          <ul>
+            <li>{item.nextPurchase}</li>
+            <li>{item.lastPurchaseDate}</li>
+            <li>{estimatedNextPurchaseDate} days until next purchase</li>
+          </ul>
+        </Modal>
+      )}
+    </>
   );
 };
 

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -3,17 +3,18 @@ import Modal from './Modal.js';
 import '../styles/Item.css';
 import dayjs from 'dayjs';
 
-const Item = ({
-  item,
-  handleChange,
-  deleteItem,
-  showModal,
-  setModalDisplay,
-}) => {
+const Item = ({ item, handleChange, deleteItem }) => {
   const [checked, setChecked] = useState(false);
+  const [showItemInfo, setShowItemInfo] = useState(false);
   const className = checked ? 'completed' : '';
-  const today = dayjs().format('d');
-  const estimatedNextPurchaseDate = +today + item.nextPurchase;
+
+  // USE IF NEED DATE FOR NEXT PURCHASE DATE
+  // const today = dayjs().format('d');
+  // const estimatedNextPurchaseDate = +today + item.nextPurchase;
+
+  const lastPurchasedDate = dayjs
+    .unix(item.lastPurchasedDate['seconds'])
+    .format('M-DD-YYYY');
 
   useEffect(() => {
     const checkDate = () => {
@@ -34,10 +35,14 @@ const Item = ({
     setChecked(check);
   }, [item]);
 
+  const handleModalChange = () => {
+    setShowItemInfo(true);
+  };
+
   return (
     <>
       <li className="list-item">
-        <label htmlFor={item.id} onClick={() => console.log('here')}>
+        <label htmlFor={item.id}>
           <input
             className="checkbox"
             type="checkbox"
@@ -47,7 +52,7 @@ const Item = ({
           />
         </label>
 
-        <span className={className} onClick={() => setModalDisplay(true)}>
+        <span className={className} onClick={handleModalChange}>
           {item.name} - next purchase in {item.nextPurchase} days
         </span>
 
@@ -55,13 +60,13 @@ const Item = ({
           Delete
         </button>
       </li>
-      {showModal && (
-        <Modal setDisplay={setModalDisplay}>
+      {showItemInfo && (
+        <Modal setDisplay={setShowItemInfo}>
           <h1>{item.name}</h1>
           <ul>
-            <li>{item.nextPurchase}</li>
-            <li>{item.lastPurchaseDate}</li>
-            <li>{estimatedNextPurchaseDate} days until next purchase</li>
+            <li>Last purchase on {lastPurchasedDate}</li>
+            <li>Next purchase in {item.nextPurchase} days</li>
+            <li>Number of Purchases: {item.numberOfPurchases}</li>
           </ul>
         </Modal>
       )}

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -76,21 +76,25 @@ const Item = ({ item, handleChange, deleteItem }) => {
         <button className="delete" onClick={() => deleteItem(item.id)}>
           Delete
         </button>
+        {showItemInfo && (
+          <Modal setDisplay={setShowItemInfo}>
+            <h2>{item.name}</h2>
+            <ul>
+              <li>Last purchased on {lastPurchasedDate}</li>
+              <li>
+                {item.nextPurchase > 1
+                  ? `Next purchase in ${item.nextPurchase} days`
+                  : `Next purchase in ${item.nextPurchase} day`}
+              </li>
+              <li>
+                {item.numberOfPurchases > 1
+                  ? `Previously purchased ${item.numberOfPurchases} times`
+                  : `Previously purchased once`}
+              </li>
+            </ul>
+          </Modal>
+        )}
       </li>
-      {showItemInfo && (
-        <Modal setDisplay={setShowItemInfo}>
-          <h2>{item.name}</h2>
-          <ul>
-            <li>Last purchased on {lastPurchasedDate}</li>
-            <li>Next purchase in {item.nextPurchase} days</li>
-            <li>
-              {item.numberOfPurchases > 1
-                ? `Previously purchased ${item.numberOfPurchases} times`
-                : `Previously purchased once`}
-            </li>
-          </ul>
-        </Modal>
-      )}
     </>
   );
 };

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -14,7 +14,7 @@ const Item = ({ item, handleChange, deleteItem }) => {
 
   const lastPurchasedDate = dayjs
     .unix(item.lastPurchasedDate['seconds'])
-    .format('M-DD-YYYY');
+    .format('M/DD/YYYY');
 
   useEffect(() => {
     const checkDate = () => {
@@ -62,11 +62,15 @@ const Item = ({ item, handleChange, deleteItem }) => {
       </li>
       {showItemInfo && (
         <Modal setDisplay={setShowItemInfo}>
-          <h1>{item.name}</h1>
+          <h2>{item.name}</h2>
           <ul>
-            <li>Last purchase on {lastPurchasedDate}</li>
+            <li>Last purchased on {lastPurchasedDate}</li>
             <li>Next purchase in {item.nextPurchase} days</li>
-            <li>Number of Purchases: {item.numberOfPurchases}</li>
+            <li>
+              {item.numberOfPurchases > 1
+                ? `Previously purchased ${item.numberOfPurchases} times`
+                : `Previously purchased once`}
+            </li>
           </ul>
         </Modal>
       )}

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -53,7 +53,7 @@ const Item = ({ item, handleChange, deleteItem }) => {
         </label>
 
         <span className={className} onClick={handleModalChange}>
-          {item.name} - next purchase in {item.nextPurchase} days
+          {item.name}
         </span>
 
         <button className="delete" onClick={() => deleteItem(item.id)}>

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -110,6 +110,8 @@ const List = ({ firestore }) => {
                           item={item}
                           handleChange={handleChange}
                           deleteItem={() => handleDelete(item.id)}
+                          showModal={showModal}
+                          setModalDisplay={setModalDisplay}
                         />
                       ) : null;
                     })}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -3,7 +3,7 @@ import '../styles/Search.css';
 
 const Search = ({ handleInputChange, inputText, handleClearInput }) => {
   return (
-    <div>
+    <>
       <input
         className="search-input"
         onChange={handleInputChange}
@@ -17,7 +17,7 @@ const Search = ({ handleInputChange, inputText, handleClearInput }) => {
           X
         </button>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/styles/Item.css
+++ b/src/styles/Item.css
@@ -19,6 +19,7 @@
   border-radius: 5px;
   margin-bottom: 10px;
   height: 35px;
+  cursor: pointer;
 }
 
 .soon-color {

--- a/src/styles/Item.css
+++ b/src/styles/Item.css
@@ -22,6 +22,10 @@
   cursor: pointer;
 }
 
+.list-item div {
+  cursor: initial;
+}
+
 .soon-color {
   background-color: #eb2f06;
 }


### PR DESCRIPTION
## Description

This PR reuses the modal component to display item details when the item is clicked.

## Related Issue

Closes #13 

## Acceptance Criteria

AC:

From the shopping list, user can tap to navigate to a detailed view of the item
Detail view includes the following information:
Name of the item
Last purchased date
Estimated number of days until the next purchase
Number of times the item has been purchased"
When in the “item details” view, a back arrow should appear in the header that takes the user back to the “list” view --> Decided to use modal, not needed

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

### After
<img width="717" alt="Screen Shot 2020-07-14 at 5 23 18 PM" src="https://user-images.githubusercontent.com/12941338/87489041-cec70e80-c5f6-11ea-85c2-badc538b7763.png">

## Testing Steps / QA Criteria

1. On the list view, click on the name of the item which should pop up a modal containing 3 bullet points
2. The modal should disappear when the "x" is clicked
